### PR TITLE
Fix array bind escaping of quotes and backslashes

### DIFF
--- a/src/execute.jl
+++ b/src/execute.jl
@@ -174,7 +174,7 @@ _param(x::AbstractVector{UInt8}) = string("\\x", bytes2hex(x))
 # convert to postgres array literal syntax: { x, y, z }
 # strings must be double-quoted and double quotes and backslashes escaped
 # missing values are NULL
-_aparam(x::AbstractString) = string("\"", replace(x, r"([\"\\])" => "\\1"), "\"")
+_aparam(x::AbstractString) = string("\"", replace(x, r"([\"\\])" => s"\\\1"), "\"")
 _aparam(::Missing) = "NULL"
 _aparam(::Nothing) = "NULL"
 _aparam(x) = _param(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -533,6 +533,19 @@ end
             parsed = Postgres.API.parse_array_by_oid(pg_array_literal(values), 23, registry)
             @test isequal(parsed, values)
         end
+
+        # The bind path builds the same literal syntax the parser consumes:
+        # element strings are double-quoted with embedded quotes and
+        # backslashes escaped. Round-trip serializer output through the parser
+        # so the two sides can never drift apart.
+        @test Postgres._param(["a\"b", "c\\d", "plain"]) ==
+              "{\"a\\\"b\", \"c\\\\d\", \"plain\"}"
+        hostile = ["He said \"hi\"", "C:\\temp\\x", "", "NULL", "{brace, comma}", "\\\""]
+        @test Postgres.API.parse_array_by_oid(Postgres._param(hostile), 25, registry) == hostile
+        for _ in 1:200
+            values = [random_array_string(rng) for _ in 1:rand(rng, 0:8)]
+            @test Postgres.API.parse_array_by_oid(Postgres._param(values), 25, registry) == values
+        end
     end
 
     if !docker_available()
@@ -717,6 +730,11 @@ end
                     bytea_param = UInt8[0xde, 0xad, 0xbe, 0xef]
                     bytea_row = only(Tables.rowtable(DBInterface.execute(conn, raw"SELECT $1::bytea AS bytea_col", (bytea_param,))))
                     @test bytea_row.bytea_col == bytea_param
+                    # String array binds must survive quotes and backslashes in
+                    # elements end to end, not just through the client parser.
+                    text_array_param = ["He said \"hi\"", "C:\\temp\\x", "", "NULL", "{brace, comma}"]
+                    text_array_row = only(Tables.rowtable(DBInterface.execute(conn, raw"SELECT $1::text[] AS text_array", (text_array_param,))))
+                    @test text_array_row.text_array == text_array_param
                     array_types_row = only(Tables.rowtable(DBInterface.execute(conn, """
                         SELECT
                             ARRAY['12345678-1234-5678-1234-567812345678']::uuid[] AS uuid_array,


### PR DESCRIPTION
## The bug

`_aparam(x::AbstractString)` in src/execute.jl escaped array-element strings with

```julia
replace(x, r"([\"\\])" => "\\1")
```

A plain `String` replacement paired with a `Regex` pattern is **literal** in Julia — capture-group references require a `SubstitutionString`. Every `"` or `\` inside a bound string-array element was replaced by the two characters `\1`, and the server's own array-literal parsing then collapsed that to `1`.

Net effect, verified against a live server: binding `["He said \"hi\""]` as `$1::text[]` stores/returns `["He said 1hi1"]` — silent data corruption on any string array bind whose elements contain quotes or backslashes.

## The fix

```julia
_aparam(x::AbstractString) = string("\"", replace(x, r"([\"\\])" => s"\\\1"), "\"")
```

One character class, now with the substitution the comment above it always described ("double quotes and backslashes escaped").

## Tests

- Serializer output is round-tripped through the package's own `parse_array_by_oid`: an exact-literal assertion, a hostile-cases list (`"`, `\`, empty string, literal `NULL`, braces/commas), and a 200-iteration fuzz reusing the existing `random_array_string` generator — so the bind and parse sides can't drift apart again. These run without Docker.
- An end-to-end `$1::text[]` bind round-trip added next to the existing bytea bind test inside the Docker-gated integration block.

## Verification

- `Pkg.test()` (Docker unavailable here, integration skipped): 868/868.
- Manual end-to-end against a live PostgreSQL 14: hostile round-trip passes with the fix; the unpatched code reproduces the `1hi1` corruption.

Found while batching `INSERT … SELECT FROM unnest($1::text[], …)` writes in LeagueEasy, which currently hand-builds array literals to work around this — that workaround can be dropped once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)